### PR TITLE
Allow for varying epsilon_i's 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: happi
 Type: Package
 Title: a hierarchical approach to pangenomics inference
-Version: 0.8.6
+Version: 0.8.7
 Authors@R: as.person(c(
     "Amy Willis <adwillis@uw.edu> [aut, cre]",
     "Pauline Trinh [aut]",

--- a/R/run_em.R
+++ b/R/run_em.R
@@ -88,7 +88,7 @@ run_em <- function(outcome  =  outcome,
                                                     epsilon = epsilon, 
                                                     covariate = em_covariate)
     
-    if ((tt > min_iterations) & (!is.na(em_estimates[tt, "loglik"]))) {
+    if ((tt > min_iterations) && (!is.na(em_estimates[tt, "loglik"]))) {
       
       pct_change_llks <- 100*abs((em_estimates[(tt - 4):tt, "loglik"] - em_estimates[(tt - 5):(tt - 1), "loglik"])/em_estimates[(tt - 5):(tt - 1), "loglik"])
       keep_going <- pct_change_llks > change_threshold # when this is all TRUE 
@@ -103,7 +103,7 @@ run_em <- function(outcome  =  outcome,
                                                  nn = nn, 
                                                  outcome = outcome, 
                                                  tt = tt)
-        } else if((tt == max_iterations) & keep_going) { # if we reach max_iterations and the model still has not converged then: 
+        } else if((tt == max_iterations) && keep_going) { # if we reach max_iterations and the model still has not converged then: 
           stop(paste("Model did not converge after", tt, "maximum number of iterations"))
          
         } else {

--- a/R/run_em.R
+++ b/R/run_em.R
@@ -91,24 +91,24 @@ run_em <- function(outcome  =  outcome,
     if ((tt > min_iterations) && (!is.na(em_estimates[tt, "loglik"]))) {
       
       pct_change_llks <- 100*abs((em_estimates[(tt - 4):tt, "loglik"] - em_estimates[(tt - 5):(tt - 1), "loglik"])/em_estimates[(tt - 5):(tt - 1), "loglik"])
-      keep_going <- pct_change_llks > change_threshold # when this is all TRUE 
+      keep_going <- pct_change_llks > change_threshold # when this is all FALSE 
       
       if(all(!keep_going)){
         message(paste("Model converged after", tt, "iterations; LL % change:", round(tail(pct_change_llks,1), 3)))
         keep_going <- FALSE 
         check_updated_f <- happi::warningcheck_update_f(probs=em_estimated_p[tt - 1, ],
-                                                 method = method,
-                                                 spline_df = spline_df, 
-                                                 quality_var = quality_var, 
-                                                 nn = nn, 
-                                                 outcome = outcome, 
-                                                 tt = tt)
-        } else if((tt == max_iterations) && keep_going) { # if we reach max_iterations and the model still has not converged then: 
-          stop(paste("Model did not converge after", tt, "maximum number of iterations"))
-         
-        } else {
-          keep_going <- TRUE 
-        }
+                                                        method = method,
+                                                        spline_df = spline_df, 
+                                                        quality_var = quality_var, 
+                                                        nn = nn, 
+                                                        outcome = outcome, 
+                                                        tt = tt)
+      } else if ((tt == max_iterations) & all(!keep_going) == FALSE) { # if we reach max_iterations and the model still has not converged then: 
+        stop(paste("Model did not converge after", tt, "maximum number of iterations"))
+        
+      } else {
+        keep_going <- TRUE 
+      }
       
     } # END if - convergence of LL's 
     

--- a/R/run_em.R
+++ b/R/run_em.R
@@ -88,7 +88,7 @@ run_em <- function(outcome  =  outcome,
                                                     epsilon = epsilon, 
                                                     covariate = em_covariate)
     
-    if ((tt > min_iterations) && (!is.na(em_estimates[tt, "loglik"]))) {
+    if ((tt > min_iterations) & (!is.na(em_estimates[tt, "loglik"]))) {
       
       pct_change_llks <- 100*abs((em_estimates[(tt - 4):tt, "loglik"] - em_estimates[(tt - 5):(tt - 1), "loglik"])/em_estimates[(tt - 5):(tt - 1), "loglik"])
       keep_going <- pct_change_llks > change_threshold # when this is all FALSE 

--- a/R/run_happi.R
+++ b/R/run_happi.R
@@ -256,7 +256,7 @@ happi <- function(outcome,
   ### If alternative LL is smaller than null:
   ## restart estimation of alternative model using the null model 
   #############################################
-  if (utils::tail(bestOut$loglik$loglik[!is.na(bestOut$loglik$loglik)],1) < tail(bestOut_null$loglik$loglik[!is.na(bestOut_null$loglik$loglik)],1)) {
+  if (utils::tail(bestOut$loglik$loglik_nopenalty[!is.na(bestOut$loglik$loglik_nopenalty)],1) < tail(bestOut_null$loglik$loglik_nopenalty[!is.na(bestOut_null$loglik$loglik_nopenalty)],1)) {
     
     message("Likelihood greater under null; restarting...")
     my_estimates <- tibble::tibble("iteration" = 0:max_iterations,

--- a/R/run_happi.R
+++ b/R/run_happi.R
@@ -27,10 +27,17 @@
 #'
 #' @return An object of class \code{happi}.
 #'
-#' @example 
+#' @examples
 #' data(TM7_data)
 #' x_matrix <- model.matrix(~tongue, data = TM7_data)
-#' happi()
+#' happi_results <- happi (outcome = TM7_data$`Cellulase/cellobiase CelA1`,
+#' covariate=x_matrix, 
+#' quality_var=TM7_data$mean_coverage,
+#' max_iterations=1000, 
+#' change_threshold=0.1,
+#' epsilon=0, 
+#' nstarts = 1, 
+#' spline_df = 3)
 #' @export
 happi <- function(outcome,
                        covariate,

--- a/man/happi.Rd
+++ b/man/happi.Rd
@@ -58,3 +58,15 @@ An object of class \code{happi}.
 \description{
 Main function for happi, p=q=1; this script contains the modularized version of happi with correct implementation of log likelihood
 }
+\examples{
+data(TM7_data)
+x_matrix <- model.matrix(~tongue, data = TM7_data)
+happi_results <- happi (outcome = TM7_data$`Cellulase/cellobiase CelA1`,
+covariate=x_matrix, 
+quality_var=TM7_data$mean_coverage,
+max_iterations=1000, 
+change_threshold=0.1,
+epsilon=0, 
+nstarts = 1, 
+spline_df = 3)
+}


### PR DESCRIPTION
Addressing [Issue #15](https://github.com/statdivlab/happi/issues/15) by adding in capacity for user to include a vector of known epsilon values, one for each observation. Backwards compatible if user provides a single value for epsilon. Additionally, suppressing messages in `happi-intro.Rmd` when `npLRT` is run. 